### PR TITLE
Fixed broken if statement in addListAfterKeypress

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,7 +21,7 @@ function addListAfterClick() {
 }
 
 function addListAfterKeypress(event) {
-    f (inputLength() > 0 && event.keyCode === 13) {
+    if (inputLength() > 0 && event.keyCode === 13) {
         createListElement();   
      }
 }


### PR DESCRIPTION
If statement was misspelled in the addListAfterKeypress function creating an undefined error